### PR TITLE
Add bounding box normalization and drawing utils

### DIFF
--- a/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/Normalization.kt
+++ b/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/Normalization.kt
@@ -1,0 +1,36 @@
+package org.kmp.playground.kflite
+
+/**
+ * Converts various bounding box formats (Pascal VOC, COCO, YOLO, etc.)
+ * into a normalized center-based format (cx, cy, w, h),
+ * then rescales them to pixel coordinates relative to the original image size.
+ *
+ * Also provides a utility to convert a center-based Box into a Path rectangle
+ * that can be drawn on a canvas.
+ *
+ * Normalization Usage:
+ * val norm = Normalization(image_height, image_width, modelimg_width, modelimg_height)
+ * val box = norm.pascalVOC(x_min, y_min, x_max, y_max)
+ *
+ *
+ * @sample org.kmp.playground.kflite.sample.addBoxRect
+ * @sample org.kmp.playground.kflite.sample.PathUsage
+ *
+ *
+ * Supported Formats for Normalization:
+ * - pascalVOC(x_min, y_min, x_max, y_max)
+ * - coco(x, y, width, height)
+ * - yolo(cx, cy, width, height)
+ * - tfObjectDetection(top, left, bottom, right)
+ * - tfRecordVariant(x_min, y_min, x_max, y_max)
+ *
+ * Output:
+ * Box object in pixel space: (center_x, center_y, width, height)
+ *
+ * Drawing:
+ * Converts center-based (cx, cy, w, h) to (left, top, right, bottom)
+ * and builds a closed rectangular Path for rendering on Canvas.
+ */
+data class Normalization(val image_height: Float, val image_width: Float, val modelimg_width: Float, val modelimg_height: Float)
+
+data class Box(val cx: Float, val cy: Float, val w: Float, val h: Float)

--- a/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/NormalizationExtensions.kt
+++ b/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/NormalizationExtensions.kt
@@ -1,0 +1,122 @@
+package org.kmp.playground.kflite
+/**
+ * Converts various bounding box formats (Pascal VOC, COCO, YOLO, etc.)
+ * into a normalized center-based format (cx, cy, w, h),
+ * then rescales them to pixel coordinates relative to the original image size.
+ *
+ * Also provides a utility to convert a center-based Box into a Path rectangle
+ * that can be drawn on a canvas.
+ *
+ * Normalization Usage:
+ * val norm = Normalization(image_height, image_width, modelimg_width, modelimg_height)
+ * val box = norm.pascalVOC(x_min, y_min, x_max, y_max)
+ *
+ *
+ * @sample org.kmp.playground.kflite.sample.addBoxRect
+ * @sample org.kmp.playground.kflite.sample.PathUsage
+ *
+ *
+ * Supported Formats for Normalization:
+ * - pascalVOC(x_min, y_min, x_max, y_max)
+ * - coco(x, y, width, height)
+ * - yolo(cx, cy, width, height)
+ * - tfObjectDetection(top, left, bottom, right)
+ * - tfRecordVariant(x_min, y_min, x_max, y_max)
+ *
+ * Output:
+ * Box object in pixel space: (center_x, center_y, width, height)
+ *
+ * Drawing:
+ * Converts center-based (cx, cy, w, h) to (left, top, right, bottom)
+ * and builds a closed rectangular Path for rendering on Canvas.
+ */
+
+
+fun Normalization.PascalVOC(x_min: Float, y_min: Float, x_max: Float, y_max: Float): Box{
+    val w = x_max - x_min
+    val h = y_max - y_min
+    val center_x = (x_max + x_min) / 2
+    val center_y = (y_max + y_min) / 2
+
+    return ResizeBox(
+        Box(
+            center_x / modelimg_width,
+            center_y / modelimg_height,
+            w / modelimg_width,
+            h / modelimg_height
+        ),
+        image_width,
+        image_height
+    )
+}
+
+
+fun Normalization.COCO(x: Float, y: Float, width: Float, height: Float): Box {
+    val center_x = x + width / 2
+    val center_y = y + height / 2
+    return ResizeBox(
+        Box(
+            center_x / modelimg_width,
+            center_y / modelimg_height,
+            width / modelimg_width,
+            height / modelimg_height
+        ),
+        image_width,
+        image_height
+    )
+}
+
+fun Normalization.YOLO(center_x: Float, center_y: Float, width: Float, height: Float): Box {
+    return ResizeBox(
+        Box(
+            center_x / modelimg_width,
+            center_y / modelimg_height,
+            width / modelimg_width,
+            height / modelimg_height
+        ),
+        image_width,
+        image_height)
+}
+
+fun Normalization.TFObjectDetection(top: Float, left: Float, bottom: Float, right: Float): Box {
+    val w = right - left
+    val h = bottom - top
+    val center_x = (right + left) / 2
+    val center_y = (bottom + top) / 2
+
+    return ResizeBox(
+        Box(
+            center_x / modelimg_width,
+            center_y / modelimg_height,
+            w / modelimg_width,
+            h / modelimg_height
+        ),
+        image_width,
+        image_height)
+}
+
+fun Normalization.TFRecordVariant(x_min: Float, y_min: Float, x_max: Float, y_max: Float): Box {
+    val w = x_max - x_min
+    val h = y_max - y_min
+    val center_x = (x_max + x_min) / 2
+    val center_y = (y_max + y_min) / 2
+
+    return ResizeBox(
+        Box(
+            center_x / modelimg_width,
+            center_y / modelimg_height,
+            w / modelimg_width,
+            h / modelimg_height
+        ),
+        image_width,
+        image_height)
+}
+
+fun ResizeBox(box: Box, origW: Float, origH:Float): Box{
+    return Box(
+        box.cx * origW,
+        box.cy * origH,
+        box.w * origW,
+        box.h * origH
+    )
+}

--- a/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/sample/PathSample.kt
+++ b/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/sample/PathSample.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import org.kmp.playground.kflite.Normalization
+import org.kmp.playground.kflite.Box
 
 
 
@@ -45,4 +46,3 @@ fun PathUsage(){
 }
 
 
-data class Box(val cx: Float, val cy: Float, val w: Float, val h: Float)

--- a/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/sample/PathSample.kt
+++ b/kflite/src/commonMain/kotlin/org/kmp/playground/kflite/sample/PathSample.kt
@@ -1,0 +1,48 @@
+package org.kmp.playground.kflite.sample
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import org.kmp.playground.kflite.Normalization
+
+
+
+
+fun Path.addBoxRect(box: Box) {
+    //Drawing Usage (Jetpack Compose):
+    val left = box.cx - box.w / 2
+    val top = box.cy - box.h / 2
+    val right = box.cx + box.w / 2
+    val bottom = box.cy + box.h / 2
+
+    reset()
+    moveTo(left, top)
+    lineTo(right, top)
+    lineTo(right, bottom)
+    lineTo(left, bottom)
+    close()
+}
+
+@Composable
+fun PathUsage(){
+    val path = Path().apply { addBoxRect(Normalization(
+        image_height = 1080f, //Original input height
+        image_width = 2010f, // Original input width
+        modelimg_width = 680f, //Model input width
+        modelimg_height = 680f //Model input height
+    ).YOLO(
+        center_x = 20f, //CenterX of Model Output From The Model
+        center_y = 20f,//CenterY of Model Output From The Model
+        width = 100f,  //Width of Model Output From The Model
+        height = 120f //Height of Model Output From The Model
+    )) }
+    Canvas(modifier= Modifier){
+        drawPath(path = path, color = Color.Red, style = Stroke(width = 2f))
+    }
+}
+
+
+data class Box(val cx: Float, val cy: Float, val w: Float, val h: Float)


### PR DESCRIPTION
### Bounding Box Normalization Utility

This utility introduces Normalization and Box classes to convert bounding boxes from various formats (Pascal VOC, COCO, YOLO, etc.) into a standardized center-based format (cx, cy, w, h) in pixel coordinates relative to the original image.It takes original image dimensions and model input dimensions to accurately rescale predictions. The output Box object simplifies rendering and other downstream processing of bounding boxes.